### PR TITLE
Create new `ScenariosSupport` library

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Support-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Support-Package.xcscheme
@@ -169,6 +169,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ScenariosSupportTests"
+               BuildableName = "ScenariosSupportTests"
+               BlueprintName = "ScenariosSupportTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Support-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Support-Package.xcscheme
@@ -104,6 +104,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ScenariosSupport"
+               BuildableName = "ScenariosSupport"
+               BlueprintName = "ScenariosSupport"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,10 @@ let package = Package(
             targets: ["Support"]
         ),
         .library(
+            name: "ScenariosSupport",
+            targets: ["ScenariosSupport"]
+        ),
+        .library(
             name: "TestingSupport",
             targets: ["TestingSupport"]
         ),
@@ -29,6 +33,10 @@ let package = Package(
         .target(
             name: "Support",
             dependencies: []
+        ),
+        .target(
+            name: "ScenariosSupport",
+            dependencies: ["Support"]
         ),
         .target(
             name: "TestingSupport",
@@ -45,6 +53,10 @@ let package = Package(
         .testTarget(
             name: "SupportTests",
             dependencies: ["Support", "TestingSupport"]
+        ),
+        .testTarget(
+            name: "ScenariosSupportTests",
+            dependencies: ["ScenariosSupport", "Support", "TestingSupport"]
         ),
         .testTarget(
             name: "TestingSupportTests",

--- a/Sources/ScenariosSupport/Runtime/Runtime.swift
+++ b/Sources/ScenariosSupport/Runtime/Runtime.swift
@@ -6,6 +6,8 @@ public enum Runtime {
     /// Returns all classes that (directly or indirectly) conform to ``RuntimeDiscoverable``.
     ///
     /// Calling this method has a non-trivial overhead, so you should process and cache the result as appropriate.
+    ///
+    /// See <doc:Runtime-Class-Discovery> to learn more about the purpose of this method.
     public static var allDiscoveredClasses: some Sequence<RuntimeDiscoverable.Type> {
         // AnyClass.init seems to register new objective-C class the first time it is called.
         //

--- a/Sources/ScenariosSupport/Runtime/Runtime.swift
+++ b/Sources/ScenariosSupport/Runtime/Runtime.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// A namespace for operations related to runtime.
+public enum Runtime {
+    
+    /// Returns all classes that (directly or indirectly) conform to ``RuntimeDiscoverable``.
+    ///
+    /// Calling this method has a non-trivial overhead, so you should process and cache the result as appropriate.
+    public static var allDiscoveredClasses: some Sequence<RuntimeDiscoverable.Type> {
+        // AnyClass.init seems to register new objective-C class the first time it is called.
+        //
+        // In order for the count variable to reserve enough capacity, we call this method once
+        // so that any new classes are registered to the runtime.
+        _ = [AnyClass](unsafeUninitializedCapacity: Int(1)) { buffer, initialisedCount in
+            initialisedCount = 0
+        }
+
+        // Improved thanks to some hints from https://stackoverflow.com/a/54150007
+        let count = objc_getClassList(nil, 0)
+        let classes = [AnyClass](unsafeUninitializedCapacity: Int(count)) { buffer, initialisedCount in
+            let autoreleasingPointer = AutoreleasingUnsafeMutablePointer<AnyClass>(buffer.baseAddress)
+            initialisedCount = Int(objc_getClassList(autoreleasingPointer, count))
+        }
+        
+        return classes
+            .lazy
+            // The `filter` is necessary. Without it we may crash.
+            //
+            // The cast using `as?` calls some objective-c methods on the type to check for conformance. But certain
+            // system types do not implement that method and would cause a crash (possible bug in the runtime?).
+            //
+            // `class_conformsToProtocol` is safe to call on all types, so we use it to filter down to “our” classes
+            // we try to cast them.
+            .filter { class_inherited_conformsToProtocol($0, RuntimeDiscoverable.self) }
+            .compactMap { $0 as? RuntimeDiscoverable.Type }
+    }
+    
+}
+
+private func class_inherited_conformsToProtocol(_ cls: AnyClass, _ p: Protocol) -> Bool {
+    if class_conformsToProtocol(cls, p) { return true }
+    guard let sup = class_getSuperclass(cls) else { return false }
+    return class_inherited_conformsToProtocol(sup, p)
+}

--- a/Sources/ScenariosSupport/Runtime/RuntimeDiscoverable.swift
+++ b/Sources/ScenariosSupport/Runtime/RuntimeDiscoverable.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// A protocol that marks types to be found at runtime.
+///
+/// Normally, you don’t conform a type directly to ``RuntimeDiscoverable``. Instead, you can use it as the base for a protocol that other types conform to.
+@objc public protocol RuntimeDiscoverable: AnyObject {}

--- a/Sources/ScenariosSupport/Runtime/RuntimeDiscoverable.swift
+++ b/Sources/ScenariosSupport/Runtime/RuntimeDiscoverable.swift
@@ -3,4 +3,6 @@ import Foundation
 /// A protocol that marks types to be found at runtime.
 ///
 /// Normally, you don’t conform a type directly to ``RuntimeDiscoverable``. Instead, you can use it as the base for a protocol that other types conform to.
+///
+/// See <doc:Runtime-Class-Discovery> to learn more about the purpose of this type.
 @objc public protocol RuntimeDiscoverable: AnyObject {}

--- a/Sources/ScenariosSupport/ScenariosSupport.docc/Runtime Class Discovery.md
+++ b/Sources/ScenariosSupport/ScenariosSupport.docc/Runtime Class Discovery.md
@@ -1,0 +1,41 @@
+# Runtime Class Discovery
+
+Rely on runtime to find classes conforming to a protocol.
+
+## Overview
+
+Sometimes after implementing a type we expect it to automatically “work”. For example, test types inheriting from
+`XCTestCase` are automatically detected by the testing infrastructure and will run without us having to “register” them.
+
+As another example, in an internal app we may want to provide entry points to make it easier to test various scenarios.
+It helps both with maintainability and also developer experience if the app infrastructure can automatically detect and
+use these types.
+
+### Runtime discovery
+
+``RuntimeDiscoverable`` is a marker protocol. It has no direct protocol requirements, though it can only be conformed to
+from a class (so it’s available in Objective-C runtime). ``Runtime/allDiscoveredClasses`` then returns all classes that
+conform to this protocol.
+
+Since ``RuntimeDiscoverable`` has no requirements, normally it’s used in conjunction with a refinment protocol that
+actually provides the functionality that you want to discover:
+
+```swift
+protocol Command: RuntimeDiscoverable { 
+    static var name: String { get }
+    static func run()
+}
+
+class Echo: Command {/*...*/}
+class Cat: Command {/*...*/}
+
+// An array containing `Echo.self` and `Cat.self`.
+let commands = Runtime.allDiscoveredClasses.compactMap { $0 as? Command.Type }
+```
+
+## Topics
+
+### Runtime Class Discovery
+
+- ``RuntimeDiscoverable``
+- ``Runtime``

--- a/Sources/ScenariosSupport/ScenariosSupport.docc/ScenariosSupport.md
+++ b/Sources/ScenariosSupport/ScenariosSupport.docc/ScenariosSupport.md
@@ -1,0 +1,18 @@
+# ``ScenariosSupport``
+
+A library to facilitate creation of internal apps and other multi-entry tools.
+
+## Overview
+
+Often when creating an app it’s necessary to also create an “internal” version of the app, for example to provide
+access to non-production environments, additional logging, and other testing and debugging facilities.
+
+Whilst this library is primarily targetting creation of such apps, many of the concerns mentioned above (such as 
+multiple entry points and varying log levels) also applies to command line tools. As such, we may explicitly address
+some of these use cases in this library. 
+
+## Topics
+
+### Scenario Generation
+
+- <doc:Runtime-Class-Discovery>

--- a/Tests/ScenariosSupportTests/Runtime/RuntimeTests.swift
+++ b/Tests/ScenariosSupportTests/Runtime/RuntimeTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import ScenariosSupport
+import TestingSupport
+import XCTest
+
+class RuntimeTests: XCTestCase {
+    
+    func testDiscoversDirectConformanceTypes() {
+        TS.assert(Runtime.allDiscoveredClasses.filter { $0 is FinalDirectConformance.Type }.count, equals: 1)
+        
+        TS.assert(Runtime.allDiscoveredClasses.filter { $0 is DirectConformance.Type }.count, equals: 2)
+        TS.assert(Runtime.allDiscoveredClasses.filter { $0 is InheritedFromDirectConformance.Type }.count, equals: 1)
+    }
+    
+    func testDiscoversTypesConformingToAProtocol() {
+        TS.assert(Runtime.allDiscoveredClasses.filter { $0 is Intermediate.Type }.count, equals: 3)
+        TS.assert(Runtime.allDiscoveredClasses.filter { $0 is FinalConformanceViaProtocol.Type }.count, equals: 1)
+        TS.assert(Runtime.allDiscoveredClasses.filter { $0 is ConformanceViaProtocol.Type }.count, equals: 2)
+        TS.assert(Runtime.allDiscoveredClasses.filter { $0 is InheritedConformanceViaProtocol.Type }.count, equals: 1)
+    }
+    
+}
+
+private final class FinalDirectConformance: RuntimeDiscoverable {}
+
+private class DirectConformance: RuntimeDiscoverable {}
+private class InheritedFromDirectConformance: DirectConformance {}
+
+private protocol Intermediate: RuntimeDiscoverable {}
+private final class FinalConformanceViaProtocol: Intermediate {}
+
+private class ConformanceViaProtocol: Intermediate {}
+private class InheritedConformanceViaProtocol: ConformanceViaProtocol {}


### PR DESCRIPTION
Create a new library that can be used in “scanario” apps and multi-entry command line tools.

The library currently supports one use case: Runtime class discovery. There is fair amount of documentation to cover this use case.

This closes #4 .