### PR TITLE
Implement `BundleMetadata`.

### DIFF
--- a/Sources/Support/Logging/Data/BundleMetadata.swift
+++ b/Sources/Support/Logging/Data/BundleMetadata.swift
@@ -1,0 +1,113 @@
+
+#if canImport(SwiftData)
+
+import Foundation
+
+/// A type capturing metadata about a bundle.
+///
+/// This type captures a subset of metadata about a bundle that is relevant for our use.
+/// ``BundleMetadata`` notably differs from `Bundle` in that it captures the information we need at initialisation time, and will fail if certain mandatory properties (such as bundle identifier) are not available.
+///
+/// ``BundleMetadata`` contains common metadata (such as identifier and name) for all bundles. In addition, for known package type it will load additional information that helps with identifying the role of the package and related bundles. See ``BundleMetadata/packageType``.
+struct BundleMetadata: Identifiable, Equatable, Sendable {
+    struct AppMetadata: Equatable, Sendable {
+        var plugins: [BundleMetadata]
+        
+        /// The bundle ID of the watchOS app’s companion iOS app.
+        ///
+        /// Present only if the bundle is a watch OS app and has a companion iOS app.
+        var watchCompanionAppBundleIdentifier: String?
+    }
+    
+    struct ExtensionMetadata: Equatable, Sendable {
+        var extensionPointIdentifier: String
+    }
+    
+    enum PackageType: Equatable, Sendable {
+        case app(AppMetadata)
+        case `extension`(ExtensionMetadata)
+        case other(typeIdentifier: String)
+    }
+    
+    var id: String
+    
+    var name: String
+    
+    var nonLocalisedDisplayName: String?
+    
+    var version: String
+    
+    var shortVersionString: String
+    
+    var packageType: PackageType
+    
+}
+
+extension BundleMetadata {
+    
+    /// Loads AppMetadata from a bundle.
+    ///
+    /// `bundle` must have an identifier, and at least one of bundle name or display name set. Otherwise `init` will return `nil`.
+    init?(from bundle: Bundle) {
+        guard
+            let id = bundle.bundleIdentifier,
+            let infoDictionary = bundle.infoDictionary,
+            let name = infoDictionary["CFBundleName"] as? String,
+            let version = infoDictionary["CFBundleVersion"] as? String,
+            let shortVersionString = infoDictionary["CFBundleShortVersionString"] as? String,
+            let packageTypeIdentifier = infoDictionary["CFBundlePackageType"] as? String
+        else {
+            return nil
+        }
+        
+        let packageType: PackageType
+        switch packageTypeIdentifier {
+        case "AAPL":
+            let plugins: [BundleMetadata]
+            if let pluginsDirectory = bundle.builtInPlugInsURL {
+                do {
+                    let pluginDirectories = try FileManager().contentsOfDirectory(at: pluginsDirectory, includingPropertiesForKeys: nil)
+                    plugins = pluginDirectories
+                        .compactMap { Bundle(url: $0) }
+                        .compactMap { BundleMetadata(from: $0) }
+                } catch {
+                    plugins = []
+                }
+            } else {
+                plugins = []
+            }
+            
+            let appMetadata = AppMetadata(
+                plugins: plugins,
+                watchCompanionAppBundleIdentifier: infoDictionary["WKCompanionAppBundleIdentifier"] as? String
+            )
+            packageType = .app(appMetadata)
+            
+        case "XPC!":
+            guard
+                let extensionInfo = infoDictionary["NSExtension"] as? NSDictionary,
+                let extensionPointIdentifier = extensionInfo["NSExtensionPointIdentifier"] as? String else {
+                return nil
+            }
+            packageType = .extension(ExtensionMetadata(extensionPointIdentifier: extensionPointIdentifier))
+            
+        default:
+            packageType = .other(typeIdentifier: packageTypeIdentifier)
+        }
+        
+        self.init(
+            id: id,
+            name: name,
+            nonLocalisedDisplayName: infoDictionary["CFBundleDisplayName"] as? String,
+            version: version,
+            shortVersionString: shortVersionString,
+            packageType: packageType
+        )
+    }
+    
+    /// BundleMetadata associated with the main bundle.
+    public static let main = BundleMetadata(from: .main)!
+    
+}
+
+#endif

--- a/Tests/SupportTests/Logging/Data/BundleMetadataTests.swift
+++ b/Tests/SupportTests/Logging/Data/BundleMetadataTests.swift
@@ -1,0 +1,195 @@
+#if canImport(SwiftData)
+#if swift(>=6.2) // Required for the raw identifier in test method names.
+
+import Foundation
+import Testing
+@testable import Support
+import TestingSupport
+
+@Suite
+struct BundleMetadataTests {
+    // MARK: - Baseline
+    
+    @Test func `Can’t make metadata from empty bundle`() async throws {
+        try Bundle.withTemporaryBundle { bundle in
+            #expect(BundleMetadata(from: bundle) == nil)
+        }
+    }
+    
+    @Test func `Make metadata with minimum required fields`() async throws {
+        let bundleIdentifier = String.random()
+        let name = String.random()
+        let version = String.random()
+        let shortVersionString = String.random()
+        let packageType = String.random()
+        let info = [
+            "CFBundleIdentifier": bundleIdentifier,
+            "CFBundleName": name,
+            "CFBundleVersion": version,
+            "CFBundleShortVersionString": shortVersionString,
+            "CFBundlePackageType": packageType,
+        ]
+        try Bundle.withTemporaryBundle(info: info) { bundle in
+            let metadata = try #require(BundleMetadata(from: bundle))
+            #expect(metadata.id == bundleIdentifier)
+            #expect(metadata.name == name)
+            #expect(metadata.nonLocalisedDisplayName == nil)
+            #expect(metadata.version == version)
+            #expect(metadata.shortVersionString == shortVersionString)
+            #expect(metadata.packageType == .other(typeIdentifier: packageType))
+        }
+    }
+    
+    @Test func `Make metadata with display name included`() async throws {
+        let bundleIdentifier = String.random()
+        let name = String.random()
+        let displayName = String.random()
+        let version = String.random()
+        let shortVersionString = String.random()
+        let packageType = String.random()
+        let info = [
+            "CFBundleIdentifier": bundleIdentifier,
+            "CFBundleName": name,
+            "CFBundleDisplayName": displayName,
+            "CFBundleVersion": version,
+            "CFBundleShortVersionString": shortVersionString,
+            "CFBundlePackageType": packageType,
+        ]
+        try Bundle.withTemporaryBundle(info: info) { bundle in
+            let metadata = try #require(BundleMetadata(from: bundle))
+            #expect(metadata.id == bundleIdentifier)
+            #expect(metadata.name == name)
+            #expect(metadata.nonLocalisedDisplayName == displayName)
+            #expect(metadata.version == version)
+            #expect(metadata.shortVersionString == shortVersionString)
+            #expect(metadata.packageType == .other(typeIdentifier: packageType))
+        }
+    }
+    
+    // MARK: - App Bundles
+    
+    @Test func `Make metadata for app without any plugins`() async throws {
+        let info = [
+            "CFBundleIdentifier": String.random(),
+            "CFBundleName": String.random(),
+            "CFBundleVersion": String.random(),
+            "CFBundleShortVersionString": String.random(),
+            "CFBundlePackageType": "AAPL",
+        ]
+        try Bundle.withTemporaryBundle(info: info) { bundle in
+            let metadata = try #require(BundleMetadata(from: bundle))
+            #expect(metadata.packageType == .app(BundleMetadata.AppMetadata(plugins: [])))
+        }
+    }
+    
+    @Test func `Make metadata for app with a plugin`() async throws {
+        let info = [
+            "CFBundleIdentifier": String.random(),
+            "CFBundleName": String.random(),
+            "CFBundleVersion": String.random(),
+            "CFBundleShortVersionString": String.random(),
+            "CFBundlePackageType": "AAPL",
+        ]
+        let extensionName = String.random()
+        let extensionId = String.random()
+        let extensionInfos: [String : [String : String]] = [
+            extensionName: [
+                "CFBundleIdentifier": extensionId,
+                "CFBundleName": String.random(),
+                "CFBundleVersion": String.random(),
+                "CFBundleShortVersionString": String.random(),
+                "CFBundlePackageType": String.random(),
+            ]
+        ]
+        try Bundle.withTemporaryBundle(info: info, extensionInfos: extensionInfos) { bundle in
+            let metadata = try #require(BundleMetadata(from: bundle))
+            guard case .app(let appMetadata) = metadata.packageType else {
+                struct ExpectedAppPackage: Error {}
+                throw ExpectedAppPackage()
+            }
+            #expect(appMetadata.plugins.count == 1)
+            let plugin = try #require(appMetadata.plugins.first)
+            #expect(plugin.id == extensionId)
+        }
+    }
+    
+    // MARK: – Watch App Bundles
+    
+    @Test func `Make metadata for a watch app without any plugins`() async throws {
+        let watchCompanionAppBundleIdentifier = String.random()
+        let info = [
+            "CFBundleIdentifier": String.random(),
+            "CFBundleName": String.random(),
+            "CFBundleVersion": String.random(),
+            "CFBundleShortVersionString": String.random(),
+            "WKCompanionAppBundleIdentifier": watchCompanionAppBundleIdentifier,
+            "CFBundlePackageType": "AAPL",
+        ]
+        try Bundle.withTemporaryBundle(info: info) { bundle in
+            let metadata = try #require(BundleMetadata(from: bundle))
+            guard case .app(let appMetadata) = metadata.packageType else {
+                struct ExpectedAppPackage: Error {}
+                throw ExpectedAppPackage()
+            }
+            #expect(appMetadata.watchCompanionAppBundleIdentifier == watchCompanionAppBundleIdentifier)
+        }
+    }
+    
+    // MARK: - Extension Bundles
+    
+    @Test func `Make metadata for an extension`() async throws {
+        let extensionPointIdentifier = String.random()
+        let info = [
+            "CFBundleIdentifier": String.random(),
+            "CFBundleName": String.random(),
+            "CFBundleVersion": String.random(),
+            "CFBundleShortVersionString": String.random(),
+            "CFBundlePackageType": "XPC!",
+            "NSExtension": [
+                "NSExtensionPointIdentifier": extensionPointIdentifier
+            ]
+        ] as NSDictionary
+        try Bundle.withTemporaryBundle(info: info) { bundle in
+            let metadata = try #require(BundleMetadata(from: bundle))
+            guard case .extension(let extensionMetadata) = metadata.packageType else {
+                struct ExpectedExtensionPackage: Error {}
+                throw ExpectedExtensionPackage()
+            }
+            #expect(extensionMetadata.extensionPointIdentifier == extensionPointIdentifier)
+        }
+    }
+    
+    
+}
+
+private extension Bundle {
+    
+    static func withTemporaryBundle<T>(info: NSDictionary, extensionInfos: [String: [String: String]] = [:], work closure: (Bundle) throws -> T) throws -> T {
+        let fileManager = FileManager()
+        return try fileManager.withTemporaryDirectory { url in
+            let encoder = PropertyListEncoder()
+            
+            try PropertyListSerialization.data(fromPropertyList: info, format: .binary, options: .zero).write(to: url.appending(component: "Info.plist"))
+            
+            if !extensionInfos.isEmpty {
+                let pluginsDirectory = url.appending(component: "PlugIns", directoryHint: .isDirectory)
+                for (name, extensionInfo) in extensionInfos {
+                    let extensionDirectory = pluginsDirectory.appending(component: "\(name).appex", directoryHint: .isDirectory)
+                    try fileManager.createDirectory(at: extensionDirectory, withIntermediateDirectories: true)
+                    try encoder.encode(extensionInfo).write(to: extensionDirectory.appending(component: "Info.plist"))
+                }
+            }
+            
+            let bundle = try #require(Bundle(url: url))
+            return try closure(bundle)
+        }
+    }
+    
+    static func withTemporaryBundle<T>(info: [String: String] = [:], extensionInfos: [String: [String: String]] = [:], work closure: (Bundle) throws -> T) throws -> T {
+        try withTemporaryBundle(info: info as NSDictionary, extensionInfos: extensionInfos, work: closure)
+    }
+    
+}
+
+#endif
+#endif


### PR DESCRIPTION
All executables in an app are organised as bundles.

- An app itself is bundle, containing the Info.plist, executable, and assets.
- An app can contain other bundles. Relevant to us, an app can contain “plug in” bundles; each of which represents an extension such as a widget extension.
- A watch app can indicate which iOS app it has as a companion.

`BundleMetadata` extract these properties so its ready for us to use, typically by accessing `BundleMetadata.main` – though it is not used in this PR yet.

Note that when using `BundleMetadata.main`, “parent” bundles know about the children, but the children only know about themselves. That is:

- when called from an app, we can see which extensions it has with what info, type, etc.
- when called from an extension, we know the extension’s info, but _not_ which app it has been embedded in 