### PR TITLE
`LogStoreProtocol` uses `any Sequence` instead of `AnySequence`.

### DIFF
--- a/Sources/Support/Logging/LogMonitor/LogStoreProtocol.swift
+++ b/Sources/Support/Logging/LogMonitor/LogStoreProtocol.swift
@@ -6,7 +6,7 @@ protocol LogEntryProtocol {
 }
 
 protocol LogStoreProtocol {
-    func entries(after date: Date) throws -> AnySequence<LogEntryProtocol>
+    func entries(after date: Date) throws -> any Sequence<any LogEntryProtocol>
 }
 
 #if canImport(OSLog)
@@ -17,9 +17,9 @@ import OSLog
 extension OSLogEntry: LogEntryProtocol {}
 
 extension OSLogStore: LogStoreProtocol {
-    func entries(after date: Date) throws -> AnySequence<any LogEntryProtocol> {
+    func entries(after date: Date) throws -> any Sequence<any LogEntryProtocol> {
         let osLogEntries: AnySequence<OSLogEntry> = try entries(after: date)
-        return AnySequence(osLogEntries.map { $0 as LogEntryProtocol })
+        return osLogEntries.lazy.map { $0 as LogEntryProtocol }
     }
 }
 


### PR DESCRIPTION
`AnySequence` was created during an earlier version of Swift that could not support `any Sequence`.

Also, independent of the above, changed the `map` to be lazy so we don’t impact performance characteristics of the original sequence.