### PR TITLE
Add initial tests for LogMonitor

### DIFF
--- a/Sources/Support/Logging/Convention.swift
+++ b/Sources/Support/Logging/Convention.swift
@@ -5,6 +5,7 @@ import Foundation
 public struct LogStorageConvention: Sendable {
     public enum BaseStorageLocation: Sendable {
         case appGroup(identifier: String)
+        case customLocation(url: URL)
     }
 
     /// Indicates where on the system the logs should be stored
@@ -56,6 +57,8 @@ extension FileManager {
                 throw UndefinedAppGroup(identifier: identifier)
             }
             return appGroupFolder
+        case .customLocation(let url):
+            return url
         }
     }
     

--- a/Sources/Support/Logging/Data/DeviceMetadata.swift
+++ b/Sources/Support/Logging/Data/DeviceMetadata.swift
@@ -1,0 +1,33 @@
+#if canImport(SwiftData)
+
+import Foundation
+
+struct DeviceMetadata: Equatable, Sendable {
+    var operatingSystemVersion: String
+    var deviceModel: String
+
+    init(operatingSystemVersion: String, deviceModel: String) {
+        self.operatingSystemVersion = operatingSystemVersion
+        self.deviceModel = deviceModel
+    }
+}
+
+extension DeviceMetadata {
+    static let main = DeviceMetadata(
+        operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+        deviceModel: deviceModel()
+    )
+    
+    private static func deviceModel() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+        return identifier
+    }
+}
+
+#endif

--- a/Sources/Support/Logging/LogMonitor/AppRun.swift
+++ b/Sources/Support/Logging/LogMonitor/AppRun.swift
@@ -5,7 +5,7 @@ import SwiftData
 
 @Model
 public class AppRun {
-    struct Snapshot: Codable {
+    struct Snapshot: Codable, Equatable {
         struct Info: Codable, Equatable {
             var appVersion: String
             var operatingSystemVersion: String

--- a/Sources/Support/Logging/LogMonitor/LogEntry.swift
+++ b/Sources/Support/Logging/LogMonitor/LogEntry.swift
@@ -6,7 +6,7 @@ import SwiftData
 
 @Model
 public class LogEntry {
-    struct Snapshot: Codable {
+    struct Snapshot: Codable, Equatable {
         var date: Date
         var composedMessage: String
         var level: String?

--- a/Sources/Support/Logging/LogMonitor/LogMonitor.swift
+++ b/Sources/Support/Logging/LogMonitor/LogMonitor.swift
@@ -1,4 +1,3 @@
-#if canImport(OSLog)
 #if canImport(SwiftData)
 
 import Foundation
@@ -90,6 +89,13 @@ public actor OSLogMonitor {
             try? await Task.sleep(for: .seconds(1))
         }
     }
+
+    func getAppRuns() throws -> [AppRun.Snapshot] {
+        let context = ModelContext(modelContainer)
+        let descriptor = FetchDescriptor<AppRun>(predicate: nil, sortBy: [SortDescriptor(\.launchDate)])
+        let runs = try context.fetch(descriptor)
+        return runs.map(\.snapshot)
+    }
     
     public func export() throws -> String {
         let context = ModelContext(modelContainer)
@@ -107,6 +113,7 @@ public actor OSLogMonitor {
     
 }
 
+#if canImport(OSLog)
 public extension OSLogMonitor {
     init(
         convention: LogStorageConvention,
@@ -122,6 +129,7 @@ public extension OSLogMonitor {
         )
     }
 }
+#endif
 
 struct Logs: Codable {
     var runs: [AppRun.Snapshot]
@@ -148,5 +156,4 @@ private func deviceModel() -> String {
     return identifier
 }
 
-#endif
 #endif

--- a/Sources/Support/Logging/LogMonitor/LogMonitor.swift
+++ b/Sources/Support/Logging/LogMonitor/LogMonitor.swift
@@ -59,14 +59,14 @@ public actor OSLogMonitor {
             configurations: configuration
         )
 
-        Task.detached { [logger] in
+        Task.detached {
             do {
                 try await self.monitorOSLog(
                     bundleMetadata: bundleMetadata,
                     deviceMetadata: deviceMetadata
                 )
             } catch {
-                logger.error("\(error.localizedDescription)")
+                self.logger.error("\(error.localizedDescription)")
             }
         }
     }

--- a/Sources/Support/Logging/LogMonitor/LogMonitor.swift
+++ b/Sources/Support/Logging/LogMonitor/LogMonitor.swift
@@ -96,12 +96,9 @@ public actor OSLogMonitor {
         let runs = try context.fetch(descriptor)
         return runs.map(\.snapshot)
     }
-    
+
     public func export() throws -> String {
-        let context = ModelContext(modelContainer)
-        let descriptor = FetchDescriptor<AppRun>(predicate: nil, sortBy: [SortDescriptor(\.launchDate)])
-        let runs = try context.fetch(descriptor)
-        let runSnapshots = runs.map(\.snapshot)
+        let runSnapshots = try getAppRuns()
         let logs = Logs(runs: runSnapshots)
         let encoder = mutating(JSONEncoder()) {
             $0.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
+++ b/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
@@ -6,7 +6,7 @@ import Foundation
 
 struct OSLogMonitorTests {
     @Test
-    func `fetch initial logs`() async throws {
+    func fetchInitialLogs() async throws {
         let temporaryDirectory = FileManager().temporaryDirectory.appending(component: UUID().uuidString, directoryHint: .isDirectory)
         defer { try! FileManager().removeItem(at: temporaryDirectory) }
 
@@ -55,8 +55,6 @@ struct OSLogMonitorTests {
     }
 }
 
-#endif
-
 private class LogStore: LogStoreProtocol {
     private var entries: [LogEntryProtocol]
 
@@ -78,3 +76,5 @@ private struct LogEntry: LogEntryProtocol {
     let composedMessage: String
     let date: Date
 }
+
+#endif

--- a/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
+++ b/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
@@ -1,0 +1,76 @@
+#if canImport(SwiftData)
+
+import Testing
+import Foundation
+@testable import Support
+
+struct OSLogMonitorTests {
+    @Test
+    func `fetch initial logs`() async throws {
+        let temporaryDirectory = FileManager().temporaryDirectory.appending(component: UUID().uuidString, directoryHint: .isDirectory)
+        defer { try! FileManager().removeItem(at: temporaryDirectory) }
+
+        let logStore = LogStore(entries: [
+            LogEntry(composedMessage: "Log message", date: .init(timeIntervalSince1970: 1))
+        ])
+
+        let logMonitor = try OSLogMonitor(
+            convention: LogStorageConvention(
+                baseStorageLocation: .customLocation(url: temporaryDirectory),
+                basePathComponents: ["Test"]
+            ),
+            bundleMetadata: BundleMetadata(
+                id: "id",
+                name: "name",
+                version: "1",
+                shortVersionString: "1",
+                packageType: .extension(.init(extensionPointIdentifier: "widget"))
+            ),
+            logStore: logStore,
+            appLaunchDate: .init(timeIntervalSince1970: 1)
+        )
+
+        try await Task.sleep(for: .seconds(1))
+
+        let exportedLogs = try await logMonitor.getAppRuns()
+        #expect(
+            exportedLogs == [
+                AppRun.Snapshot(
+                    info: .init(
+                        appVersion: "1",
+                        operatingSystemVersion: "Version 15.7 (Build 24G222)",
+                        launchDate: .init(timeIntervalSince1970: 1),
+                        device: "arm64"
+                    ),
+                    logEntries: [
+                        .init(date: .init(timeIntervalSince1970: 1), composedMessage: "Log message")
+                    ]
+                )
+            ]
+        )
+    }
+}
+
+#endif
+
+private class LogStore: LogStoreProtocol {
+    private var entries: [LogEntryProtocol]
+
+    init(entries: [LogEntry]) {
+        self.entries = entries
+    }
+
+    func log(entry: LogEntry) {
+        self.entries.append(entry)
+    }
+
+    func entries(after date: Date) throws -> any Sequence<any LogEntryProtocol> {
+        let predicate = #Predicate<LogEntryProtocol> { $0.date > date }
+        return try entries.filter(predicate)
+    }
+}
+
+private struct LogEntry: LogEntryProtocol {
+    let composedMessage: String
+    let date: Date
+}

--- a/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
+++ b/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
@@ -26,6 +26,10 @@ struct OSLogMonitorTests {
                 shortVersionString: "1",
                 packageType: .extension(.init(extensionPointIdentifier: "widget"))
             ),
+            deviceMetadata: DeviceMetadata(
+                operatingSystemVersion: "26.0",
+                deviceModel: "iPhone 17 Pro"
+            ),
             logStore: logStore,
             appLaunchDate: .init(timeIntervalSince1970: 1)
         )
@@ -38,9 +42,9 @@ struct OSLogMonitorTests {
                 AppRun.Snapshot(
                     info: .init(
                         appVersion: "1",
-                        operatingSystemVersion: "Version 15.7 (Build 24G222)",
+                        operatingSystemVersion: "26.0",
                         launchDate: .init(timeIntervalSince1970: 1),
-                        device: "arm64"
+                        device: "iPhone 17 Pro"
                     ),
                     logEntries: [
                         .init(date: .init(timeIntervalSince1970: 1), composedMessage: "Log message")


### PR DESCRIPTION
- Adds a `customLocation` to the `BaseStorageLocation` which for now is used in tests to store the files in a temporary directory
- Introduces internal `DeviceMetadata`, also helpful when testing
- Add initial tests for fetching the logs from `OSLogMonitor`.