### PR TITLE
Use MainActor for OSLogMonitor

### DIFF
--- a/Sources/Support/Logging/LogMonitor/LogMonitor.swift
+++ b/Sources/Support/Logging/LogMonitor/LogMonitor.swift
@@ -10,7 +10,7 @@ import UniformTypeIdentifiers
 // Context: Due to limitations in testing MainActor ensures that the tasks are run sequentially.
 @MainActor
 public class OSLogMonitor {
-    private let logger = Logger(subsystem: "com.zuhlke.Suport", category: "LogMonitor")
+    private let logger = Logger(subsystem: "com.zuhlke.Support", category: "LogMonitor")
 
     let appLaunchDate: Date
     let logStore: LogStoreProtocol

--- a/Sources/Support/Logging/LogMonitor/LogMonitor.swift
+++ b/Sources/Support/Logging/LogMonitor/LogMonitor.swift
@@ -5,7 +5,8 @@ import OSLog
 import SwiftData
 import UniformTypeIdentifiers
 
-public actor OSLogMonitor {
+@MainActor
+public class OSLogMonitor {
     private let logger = Logger(subsystem: "com.zuhlke.Suport", category: "LogMonitor")
 
     let appLaunchDate: Date
@@ -59,7 +60,7 @@ public actor OSLogMonitor {
             configurations: configuration
         )
 
-        Task.detached {
+        Task {
             do {
                 try await self.monitorOSLog(
                     bundleMetadata: bundleMetadata,
@@ -123,7 +124,7 @@ public actor OSLogMonitor {
 
 #if canImport(OSLog)
 public extension OSLogMonitor {
-    init(
+    convenience init(
         convention: LogStorageConvention,
         bundleMetadata: BundleMetadata = .main,
         appLaunchDate: Date = .now

--- a/Sources/Support/Logging/LogMonitor/LogMonitor.swift
+++ b/Sources/Support/Logging/LogMonitor/LogMonitor.swift
@@ -5,6 +5,9 @@ import OSLog
 import SwiftData
 import UniformTypeIdentifiers
 
+// TODO: - Avoid running on MainActor as this is not something related to UI.
+//
+// Context: Due to limitations in testing MainActor ensures that the tasks are run sequentially.
 @MainActor
 public class OSLogMonitor {
     private let logger = Logger(subsystem: "com.zuhlke.Suport", category: "LogMonitor")

--- a/Sources/TestingSupport/Extensions/FileManager.swift
+++ b/Sources/TestingSupport/Extensions/FileManager.swift
@@ -23,7 +23,7 @@ extension FileManager {
     /// - Parameter operation: The operation to perform in the directory.
     /// - Returns: The result of `operation`.
     /// - Throws: If `operation` throws, or if fails to create a temporary folder.
-    public func withTemporaryDirectory<Output>(perform operation: (URL) async throws -> Output) async throws -> Output {
+    public func withTemporaryDirectory<Output>(perform operation: @Sendable (URL) async throws -> Output) async throws -> Output {
         let directory = try url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: temporaryDirectory, create: true)
         defer { try? removeItem(at: directory) }
         

--- a/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
+++ b/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
@@ -4,6 +4,7 @@ import Testing
 import Foundation
 @testable import Support
 
+@MainActor
 struct OSLogMonitorTests {
     @Test
     func createsAppLogManifestAndLogFiles_forAppPackage() async throws {
@@ -113,9 +114,13 @@ struct OSLogMonitorTests {
             appLaunchDate: .init(timeIntervalSince1970: 1)
         )
 
-        try await Task.sleep(for: .seconds(1))
-
-        let exportedLogs = try await logMonitor.getAppRuns()
+        let getAppRunsTask = Task {
+            let exportedLogs = try logMonitor.getAppRuns()
+            return exportedLogs
+        }
+        
+        let exportedLogs = try await getAppRunsTask.value
+        
         #expect(
             exportedLogs == [
                 AppRun.Snapshot(

--- a/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
+++ b/Tests/SupportTests/Logging/LogMonitor/LogMonitorTests.swift
@@ -9,133 +9,131 @@ struct OSLogMonitorTests {
     @Test
     func createsAppLogManifestAndLogFiles_forAppPackage() async throws {
         let fileManager = FileManager()
-        let temporaryDirectory = fileManager.temporaryDirectory.appending(component: UUID().uuidString, directoryHint: .isDirectory)
-        defer { try! fileManager.removeItem(at: temporaryDirectory) }
-        
-        let logStore = LogStore(entries: [])
-        
-        let _ = try OSLogMonitor(
-            convention: LogStorageConvention(
-                baseStorageLocation: .customLocation(url: temporaryDirectory),
-                basePathComponents: ["Test"]
-            ),
-            bundleMetadata: BundleMetadata(
-                id: "com.zuhlke.Support",
-                name: "Support",
-                version: "1",
-                shortVersionString: "1",
-                packageType: .app(.init(plugins: []))
-            ),
-            deviceMetadata: DeviceMetadata(
-                operatingSystemVersion: "26.0",
-                deviceModel: "iPhone 17 Pro"
-            ),
-            logStore: logStore,
-            appLaunchDate: .init(timeIntervalSince1970: 1)
-        )
-
-        let manifestFile = temporaryDirectory.appending(path: "Test/Manifests/com.zuhlke.Support.json")
-        let manifestFileContents = try Data(contentsOf: manifestFile)
-        let appLogManifest = try JSONDecoder().decode(AppLogManifest.self, from: manifestFileContents)
-        #expect(
-            appLogManifest == AppLogManifest(
-                manifestVersion: 1,
-                id: "com.zuhlke.Support",
-                name: "Support",
-                extensions: [:]
+        try fileManager.withTemporaryDirectory { url in
+            let logStore = LogStore(entries: [])
+            
+            let _ = try OSLogMonitor(
+                convention: LogStorageConvention(
+                    baseStorageLocation: .customLocation(url: url),
+                    basePathComponents: ["Test"]
+                ),
+                bundleMetadata: BundleMetadata(
+                    id: "com.zuhlke.Support",
+                    name: "Support",
+                    version: "1",
+                    shortVersionString: "1",
+                    packageType: .app(.init(plugins: []))
+                ),
+                deviceMetadata: DeviceMetadata(
+                    operatingSystemVersion: "26.0",
+                    deviceModel: "iPhone 17 Pro"
+                ),
+                logStore: logStore,
+                appLaunchDate: .init(timeIntervalSince1970: 1)
             )
-        )
-        
-        let logFile = temporaryDirectory.appending(path: "Test/Logs/com.zuhlke.Support.logs")
-        #expect(fileManager.fileExists(atPath: logFile.path()))
+
+            let manifestFile = url.appending(path: "Test/Manifests/com.zuhlke.Support.json")
+            let manifestFileContents = try Data(contentsOf: manifestFile)
+            let appLogManifest = try JSONDecoder().decode(AppLogManifest.self, from: manifestFileContents)
+            #expect(
+                appLogManifest == AppLogManifest(
+                    manifestVersion: 1,
+                    id: "com.zuhlke.Support",
+                    name: "Support",
+                    extensions: [:]
+                )
+            )
+            
+            let logFile = url.appending(path: "Test/Logs/com.zuhlke.Support.logs")
+            #expect(fileManager.fileExists(atPath: logFile.path()))
+        }
     }
     
     @Test
     func createsLogFile_forExtensionPackage() async throws {
         let fileManager = FileManager()
-        let temporaryDirectory = fileManager.temporaryDirectory.appending(component: UUID().uuidString, directoryHint: .isDirectory)
-        defer { try! fileManager.removeItem(at: temporaryDirectory) }
-        
-        let logStore = LogStore(entries: [])
-        
-        let _ = try OSLogMonitor(
-            convention: LogStorageConvention(
-                baseStorageLocation: .customLocation(url: temporaryDirectory),
-                basePathComponents: ["Test"]
-            ),
-            bundleMetadata: BundleMetadata(
-                id: "com.zuhlke.Support.extension",
-                name: "Support",
-                version: "1",
-                shortVersionString: "1",
-                packageType: .extension(.init(extensionPointIdentifier: "com.apple.widgetkit-extension"))
-            ),
-            deviceMetadata: DeviceMetadata(
-                operatingSystemVersion: "26.0",
-                deviceModel: "iPhone 17 Pro"
-            ),
-            logStore: logStore,
-            appLaunchDate: .init(timeIntervalSince1970: 1)
-        )
+        try fileManager.withTemporaryDirectory { url in
+            let logStore = LogStore(entries: [])
+            
+            let _ = try OSLogMonitor(
+                convention: LogStorageConvention(
+                    baseStorageLocation: .customLocation(url: url),
+                    basePathComponents: ["Test"]
+                ),
+                bundleMetadata: BundleMetadata(
+                    id: "com.zuhlke.Support.extension",
+                    name: "Support",
+                    version: "1",
+                    shortVersionString: "1",
+                    packageType: .extension(.init(extensionPointIdentifier: "com.apple.widgetkit-extension"))
+                ),
+                deviceMetadata: DeviceMetadata(
+                    operatingSystemVersion: "26.0",
+                    deviceModel: "iPhone 17 Pro"
+                ),
+                logStore: logStore,
+                appLaunchDate: .init(timeIntervalSince1970: 1)
+            )
 
-        let manifestFile = temporaryDirectory.appending(path: "Test/Manifests")
-        #expect(!fileManager.fileExists(atPath: manifestFile.path()))
-        
-        let logFile = temporaryDirectory.appending(path: "Test/Logs/com.zuhlke.Support.extension.logs")
-        #expect(fileManager.fileExists(atPath: logFile.path()))
+            let manifestFile = url.appending(path: "Test/Manifests")
+            #expect(!fileManager.fileExists(atPath: manifestFile.path()))
+            
+            let logFile = url.appending(path: "Test/Logs/com.zuhlke.Support.extension.logs")
+            #expect(fileManager.fileExists(atPath: logFile.path()))
+        }
     }
 
     @Test
     func fetchInitialLogs() async throws {
-        let temporaryDirectory = FileManager().temporaryDirectory.appending(component: UUID().uuidString, directoryHint: .isDirectory)
-        defer { try! FileManager().removeItem(at: temporaryDirectory) }
+        let fileManager = FileManager()
+        try await fileManager.withTemporaryDirectory { @MainActor url in
+            let logStore = LogStore(entries: [
+                LogEntry(composedMessage: "Log message", date: .init(timeIntervalSince1970: 1))
+            ])
 
-        let logStore = LogStore(entries: [
-            LogEntry(composedMessage: "Log message", date: .init(timeIntervalSince1970: 1))
-        ])
+            let logMonitor = try OSLogMonitor(
+                convention: LogStorageConvention(
+                    baseStorageLocation: .customLocation(url: url),
+                    basePathComponents: ["Test"]
+                ),
+                bundleMetadata: BundleMetadata(
+                    id: "id",
+                    name: "name",
+                    version: "1",
+                    shortVersionString: "1",
+                    packageType: .extension(.init(extensionPointIdentifier: "com.apple.widgetkit-extension"))
+                ),
+                deviceMetadata: DeviceMetadata(
+                    operatingSystemVersion: "26.0",
+                    deviceModel: "iPhone 17 Pro"
+                ),
+                logStore: logStore,
+                appLaunchDate: .init(timeIntervalSince1970: 1)
+            )
 
-        let logMonitor = try OSLogMonitor(
-            convention: LogStorageConvention(
-                baseStorageLocation: .customLocation(url: temporaryDirectory),
-                basePathComponents: ["Test"]
-            ),
-            bundleMetadata: BundleMetadata(
-                id: "id",
-                name: "name",
-                version: "1",
-                shortVersionString: "1",
-                packageType: .extension(.init(extensionPointIdentifier: "com.apple.widgetkit-extension"))
-            ),
-            deviceMetadata: DeviceMetadata(
-                operatingSystemVersion: "26.0",
-                deviceModel: "iPhone 17 Pro"
-            ),
-            logStore: logStore,
-            appLaunchDate: .init(timeIntervalSince1970: 1)
-        )
-
-        let getAppRunsTask = Task {
-            let exportedLogs = try logMonitor.getAppRuns()
-            return exportedLogs
+            let getAppRunsTask = Task {
+                let exportedLogs = try logMonitor.getAppRuns()
+                return exportedLogs
+            }
+            
+            let exportedLogs = try await getAppRunsTask.value
+            
+            #expect(
+                exportedLogs == [
+                    AppRun.Snapshot(
+                        info: .init(
+                            appVersion: "1",
+                            operatingSystemVersion: "26.0",
+                            launchDate: .init(timeIntervalSince1970: 1),
+                            device: "iPhone 17 Pro"
+                        ),
+                        logEntries: [
+                            .init(date: .init(timeIntervalSince1970: 1), composedMessage: "Log message")
+                        ]
+                    )
+                ]
+            )
         }
-        
-        let exportedLogs = try await getAppRunsTask.value
-        
-        #expect(
-            exportedLogs == [
-                AppRun.Snapshot(
-                    info: .init(
-                        appVersion: "1",
-                        operatingSystemVersion: "26.0",
-                        launchDate: .init(timeIntervalSince1970: 1),
-                        device: "iPhone 17 Pro"
-                    ),
-                    logEntries: [
-                        .init(date: .init(timeIntervalSince1970: 1), composedMessage: "Log message")
-                    ]
-                )
-            ]
-        )
     }
 }
 
@@ -151,8 +149,7 @@ private class LogStore: LogStoreProtocol {
     }
 
     func entries(after date: Date) throws -> any Sequence<any LogEntryProtocol> {
-        let predicate = #Predicate<LogEntryProtocol> { $0.date > date }
-        return try entries.filter(predicate)
+        return entries.filter { $0.date > date }
     }
 }
 


### PR DESCRIPTION
Using MainActor for now to avoid flakiness in the tests by removing `Task.sleep(for: .seconds(1))`.

> Will check if there's a way for us to run on a different actor next so we don't overload `MainActor` with background task.