### PR TITLE
Rename `AppGroupLogView` to `LogBrowserStack`.

### DIFF
--- a/LogViewer/LogViewer/LogViewerApp.swift
+++ b/LogViewer/LogViewer/LogViewerApp.swift
@@ -7,7 +7,7 @@ import SwiftUI
 struct LogViewerApp: App {
     var body: some Scene {
         WindowGroup {
-            AppGroupLogView(convention: .commonAppGroup(identifier: "group.com.zuhlke.diagnostics"))
+            LogBrowserStack(storageConvention: .commonAppGroup(identifier: "group.com.zuhlke.diagnostics"))
         }
     }
 }

--- a/Sources/LoggingUI/LogBrowserStack.swift
+++ b/Sources/LoggingUI/LogBrowserStack.swift
@@ -4,21 +4,21 @@ import Support
 import SwiftData
 import SwiftUI
 
-/// A view that displays logs organized by app groups.
+/// A view that displays a list of identified apps and executables and provide access to browse their logs.
 ///
-/// `AppGroupLogView` provides a hierarchical navigation interface for browsing logs
+/// ``LogBrowserStack`` provides a hierarchical navigation interface for browsing logs
 /// across multiple applications and their extensions (main app, widgets, etc.).
 @available(iOS 26.0, macOS 26.0, *)
 @available(watchOS, unavailable)
-public struct AppGroupLogView: View {
+public struct LogBrowserStack: View {
     let logRetriever: LogRetriever
 
-    /// Creates a new app group log view with the specified logging convention.
+    /// Creates a browser stack for apps following the specified logging convention.
     ///
-    /// - Parameter convention: The log storage convention used to locate and retrieve logs.
-    public init(convention: LogStorageConvention) {
+    /// - Parameter storageConventin: The log storage convention used to locate and retrieve logs.
+    public init(storageConvention: LogStorageConvention) {
         // TODO: (P2) This force unwrap.
-        logRetriever = try! LogRetriever(convention: convention)
+        logRetriever = try! LogRetriever(convention: storageConvention)
     }
     
     public var body: some View {


### PR DESCRIPTION
Also rename the argument name in public init.

Resolves #84 .